### PR TITLE
Support --display on Mac OS by running emulator in the main thread

### DIFF
--- a/agent/emulator.py
+++ b/agent/emulator.py
@@ -89,7 +89,6 @@ class Emulator:
                 try:
                     # terrible hack. Maybe I should just do a function passing interface...
                     item, press_or_release = self.button_queue.get(block=False)
-                    print(f"button queue: {item}, {press_or_release}")
                     if item == "wait":
                         for _ in range(press_or_release):
                             if not self.pyboy.tick(1):
@@ -114,8 +113,9 @@ class Emulator:
                         self.button_queue_clear.set()
                         return
                 except KeyboardInterrupt:
-                    self.stop()
-                    break
+                    self.pyboy.stop()
+                    self.button_queue_clear.set()
+                    return
 
                 if self.button_queue.empty():
                     self.button_queue_clear.set()

--- a/agent/simple_agent.py
+++ b/agent/simple_agent.py
@@ -271,7 +271,7 @@ class SimpleAgent:
         self.pyboy_main_thread = pyboy_main_thread
         self.emulator_init_kwargs = {"rom_path": rom_path, "headless": headless, "sound": sound, "pyboy_main_thread": self.pyboy_main_thread}
         if not self.pyboy_main_thread:
-            self.emulator.initialize(**self.emulator_init_kwargs)  # Initialize the emulator
+            self.emulator.initialize(**self.emulator_init_kwargs)
         if MODEL == "CLAUDE" or MAPPING_MODEL == "CLAUDE":
             self.anthropic_client = Anthropic(api_key=API_CLAUDE, max_retries=10)
         if MODEL == "GEMINI" or MAPPING_MODEL == "GEMINI":
@@ -995,18 +995,13 @@ Pay attention to the following procedure when trying to reach a specific locatio
             thread.start()
 
             self.emulator.initialize(**self.emulator_init_kwargs) 
-            print('emulator.initialize done')
 
             return self._steps_completed
 
         logger.info(f"Starting agent loop for {num_steps} steps")
 
         if self.pyboy_main_thread:
-            while True:
-                if not self.emulator._is_initialized:
-                    time.sleep(0.1)
-                else:
-                    break
+            self.emulator.wait_for_pyboy()
 
             if self.load_state:
                 logger.info(f"Loading saved state from {self.load_state}")

--- a/main.py
+++ b/main.py
@@ -50,7 +50,13 @@ def main():
         default=None, 
         help="Path to a saved state to load"
     )
-    
+    parser.add_argument(
+        "--pyboy-main-thread", 
+        default=False, 
+        action="store_true",
+        help="Run pyboy in the main thread"
+    )
+
     args = parser.parse_args()
     
     # Get absolute path to ROM
@@ -75,7 +81,8 @@ def main():
         sound=args.sound if args.display else False,
         max_history=args.max_history,
         load_state=args.load_state,
-        location_archive_file_name="locations.pkl"
+        location_archive_file_name="locations.pkl",
+        pyboy_main_thread=args.pyboy_main_thread
     )
 
     try:

--- a/main.py
+++ b/main.py
@@ -2,7 +2,8 @@ import argparse
 import logging
 import os
 import time
-
+import sys 
+from typing import Literal
 from agent.simple_agent import SimpleAgent
 
 # Set up logging
@@ -51,9 +52,10 @@ def main():
         help="Path to a saved state to load"
     )
     parser.add_argument(
-        "--pyboy-main-thread", 
-        default=False, 
-        action="store_true",
+        "--main-thread-target", 
+        type=str, 
+        choices=["emulator", "agent", "auto"],
+        default="auto",
         help="Run pyboy in the main thread"
     )
 
@@ -74,6 +76,14 @@ def main():
     from pyboy import logging
     logging.log_level("DEBUG")
 
+    # default to running pyboy in the main thread on macOS
+    pyboy_main_thread = sys.platform == "darwin"
+
+    if args.main_thread_target == "emulator":
+        pyboy_main_thread = True
+    elif args.main_thread_target == "agent":
+        pyboy_main_thread = False
+
     # Create and run agent
     agent = SimpleAgent(
         rom_path=rom_path,
@@ -82,7 +92,7 @@ def main():
         max_history=args.max_history,
         load_state=args.load_state,
         location_archive_file_name="locations.pkl",
-        pyboy_main_thread=args.pyboy_main_thread
+        pyboy_main_thread=pyboy_main_thread
     )
 
     try:


### PR DESCRIPTION
Running with `--display` on Mac fails with this SDL2 error:

```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'API misuse: setting the main menu on a non-main thread. Main menu contents should only be modified from the main thread.'
```

In MacOS, it seems that SDL2 rendering (what pyboy does by default) is only permitted in the main thread.  (I tried switching to OpenGL rendering but it didn't work, I think for a similar reason?)

This PR adds support for running the emulator in the main thread (and the agent in a side thread) rather than vice versa.  And turns it on by default on Mac OS.

This works on my machine, but is kind of hacky / poorly documented; I had to work around some baked-in assumptions in the code that the emulator runs in a side thread.  (For example, `emulator.initialize` blocks the main thread when the emulator is running in the main thread, so we have to wait until the agent is running to call it, and likewise we can't load emulator state until the agent is running _and_ the emulator has started up. This leads to some messy conditional logic to prevent `SimpleAgent.__init__` from trying to do stuff with the emulator too early, etc.)

LMK if you have any questions or requests!